### PR TITLE
feat(actions): add complex entity and damage triggers

### DIFF
--- a/src/client/java/com/jd_skill_tree/screens/DeveloperEditorScreen.java
+++ b/src/client/java/com/jd_skill_tree/screens/DeveloperEditorScreen.java
@@ -892,7 +892,7 @@ public class DeveloperEditorScreen extends BaseOwoScreen<StackLayout> {
         content.padding(Insets.of(5));
 
         // 1. Trigger Dropdown (Always Index 0)
-        content.child(dropdown("Trigger", List.of("BLOCK_BREAK", "BLOCK_PLACE", "TIMER"), data.trigger, s -> {
+        content.child(dropdown("Trigger", List.of("BLOCK_BREAK", "BLOCK_PLACE", "TIMER", "TAKE_DAMAGE_SELF", "TAKE_DAMAGE_ATTACKER", "UNLOCK", "ATTACK_TARGET", "ATTACK_SELF"), data.trigger, s -> {
             data.trigger = s;
             rebuildActionRow(collapsible, content, data);
             updatePreview();

--- a/src/main/java/com/jd_skill_tree/mixin/BlockItemMixin.java
+++ b/src/main/java/com/jd_skill_tree/mixin/BlockItemMixin.java
@@ -15,14 +15,15 @@ public class BlockItemMixin {
 
     @Inject(method = "place(Lnet/minecraft/item/ItemPlacementContext;)Lnet/minecraft/util/ActionResult;", at = @At("RETURN"))
     private void onPlace(ItemPlacementContext context, CallbackInfoReturnable<ActionResult> cir) {
-        // Only trigger if the placement was successful (SUCCESS or CONSUME)
         if (cir.getReturnValue().isAccepted()) {
             if (context.getPlayer() != null && !context.getWorld().isClient) {
+                // FIXED: Now passes 5 arguments: owner, trigger, target, world, pos
                 SkillActionHandler.triggerActions(
                         context.getPlayer(),
+                        TriggerType.BLOCK_PLACE,
+                        context.getPlayer(), // Target is the player placing the block
                         context.getWorld(),
-                        context.getBlockPos(), // This gets the pos of the newly placed block
-                        TriggerType.BLOCK_PLACE
+                        context.getBlockPos()
                 );
             }
         }

--- a/src/main/java/com/jd_skill_tree/networking/SkillNetworking.java
+++ b/src/main/java/com/jd_skill_tree/networking/SkillNetworking.java
@@ -6,6 +6,8 @@ import com.jd_skill_tree.api.IUnlockedSkillsData;
 import com.jd_skill_tree.skills.Skill;
 import com.jd_skill_tree.skills.SkillLoader;
 import com.jd_skill_tree.skills.SkillManager;
+import com.jd_skill_tree.skills.actions.SkillAction;
+import com.jd_skill_tree.skills.actions.TriggerType;
 import com.jd_skill_tree.utils.ExperienceUtils;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
@@ -85,6 +87,12 @@ public class SkillNetworking {
                 skillData.unlockSkill(skillIdString);
                 syncSkillsToClient(player);
                 player.sendMessage(Text.of("§aSkill Unlocked: " + skillToUnlock.getName()), false);
+
+                for (SkillAction action : skillToUnlock.getActions()) {
+                    if (action.getTrigger() == TriggerType.UNLOCK) {
+                        action.run(player, player, player.getWorld(), player.getBlockPos());
+                    }
+                }
             });
         });
 

--- a/src/main/java/com/jd_skill_tree/skills/actions/BurnActionEffect.java
+++ b/src/main/java/com/jd_skill_tree/skills/actions/BurnActionEffect.java
@@ -1,6 +1,7 @@
 package com.jd_skill_tree.skills.actions;
 
 import com.google.gson.JsonObject;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.math.BlockPos;
@@ -17,19 +18,17 @@ public class BurnActionEffect implements SkillActionEffect {
     }
 
     @Override
-    public void execute(PlayerEntity player, World world, BlockPos pos) {
+    public void execute(Entity target, World world, BlockPos pos) {
         if (world.isClient) return;
-
-        // Visual/Logical fire (e.g. 100 ticks / 20 = 5 seconds of fire)
-        player.setOnFireFor(duration / 20);
+        target.setOnFireFor(duration / 20);
 
         if (ignoreArmor) {
             // In 1.20, 'magic' is the standard damage source that bypasses armor.
             // We use this for the 'ignoreArmor' toggle.
-            player.damage(world.getDamageSources().magic(), 1.0f);
+            target.damage(world.getDamageSources().magic(), 1.0f);
         } else {
             // Standard fire damage (respects armor)
-            player.damage(world.getDamageSources().onFire(), 1.0f);
+            target.damage(world.getDamageSources().onFire(), 1.0f);
         }
     }
 

--- a/src/main/java/com/jd_skill_tree/skills/actions/CommandActionEffect.java
+++ b/src/main/java/com/jd_skill_tree/skills/actions/CommandActionEffect.java
@@ -1,10 +1,14 @@
 package com.jd_skill_tree.skills.actions;
 
 import com.google.gson.JsonObject;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.JsonHelper;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec2f;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
 public class CommandActionEffect implements SkillActionEffect {
@@ -13,17 +17,41 @@ public class CommandActionEffect implements SkillActionEffect {
     public CommandActionEffect(String command) { this.command = command; }
 
     @Override
-    public void execute(PlayerEntity player, World world, BlockPos pos) {
-        if (world.isClient || !(player instanceof ServerPlayerEntity serverPlayer)) return;
-        String parsed = command.replace("@p", player.getName().getString())
-                .replace("%x%", String.valueOf(pos.getX()))
-                .replace("%y%", String.valueOf(pos.getY()))
-                .replace("%z%", String.valueOf(pos.getZ()));
-        serverPlayer.getServer().getCommandManager().executeWithPrefix(
-                serverPlayer.getCommandSource().withLevel(2).withSilent(), parsed);
+    public void execute(Entity target, World world, BlockPos pos) {
+        if (world.isClient || target == null) return;
+        MinecraftServer server = world.getServer();
+        if (server == null) return;
+
+        // 1. Determine precise coordinates
+        Vec3d coords = target.getPos();
+        Vec2f rotation = target.getRotationClient();
+        String name = target.getName().getString();
+
+        // 2. Construct Source using Helper Methods
+        // We start with the server's generic source, then chain modifiers to anchor it to the target.
+        ServerCommandSource source = server.getCommandSource()
+                .withWorld((ServerWorld) world)
+                .withPosition(coords)
+                .withRotation(rotation)
+                .withLevel(2)
+                .withSilent()
+                .withEntity(target); // This is crucial: sets the 'executor' for @s selector
+
+        // 3. Parse explicit placeholders
+        String parsed = command
+                .replace("@p", name)
+                .replace("%target%", name)
+                .replace("%uuid%", target.getUuidAsString())
+                .replace("%x%", String.valueOf(coords.x))
+                .replace("%y%", String.valueOf(coords.y))
+                .replace("%z%", String.valueOf(coords.z));
+
+        // 4. Execute
+        server.getCommandManager().executeWithPrefix(source, parsed);
     }
 
     public String getCommand() { return command; }
+
     public static CommandActionEffect fromJson(JsonObject json) {
         return new CommandActionEffect(JsonHelper.getString(json, "command"));
     }

--- a/src/main/java/com/jd_skill_tree/skills/actions/SkillAction.java
+++ b/src/main/java/com/jd_skill_tree/skills/actions/SkillAction.java
@@ -1,6 +1,7 @@
 package com.jd_skill_tree.skills.actions;
 
 import com.jd_skill_tree.skills.conditions.SkillCondition;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -8,8 +9,8 @@ import net.minecraft.world.World;
 public class SkillAction {
     private final TriggerType trigger;
     private final SkillActionEffect effect;
-    private final int interval; // used for TIMER
-    private final SkillCondition condition; // The specific condition for this action
+    private final int interval;
+    private final SkillCondition condition;
 
     public SkillAction(TriggerType trigger, SkillActionEffect effect, int interval, SkillCondition condition) {
         this.trigger = trigger;
@@ -18,20 +19,17 @@ public class SkillAction {
         this.condition = condition;
     }
 
-    /**
-     * Checks if the action is allowed to run for this player.
-     * Returns true if there is no condition, or if the condition is met.
-     */
-    public boolean shouldRun(PlayerEntity player) {
-        return condition == null || condition.test(player);
+    public boolean shouldRun(PlayerEntity owner) {
+        return condition == null || condition.test(owner);
     }
 
     /**
-     * Executes the action, BUT ONLY IF the condition is met.
+     * @param owner The player who possesses the skill (used for Conditions)
+     * @param target The entity being affected (used for Effects)
      */
-    public void run(PlayerEntity player, World world, BlockPos pos) {
-        if (shouldRun(player)) {
-            effect.execute(player, world, pos);
+    public void run(PlayerEntity owner, Entity target, World world, BlockPos pos) {
+        if (shouldRun(owner)) {
+            effect.execute(target, world, pos);
         }
     }
 

--- a/src/main/java/com/jd_skill_tree/skills/actions/SkillActionEffect.java
+++ b/src/main/java/com/jd_skill_tree/skills/actions/SkillActionEffect.java
@@ -1,9 +1,10 @@
 package com.jd_skill_tree.skills.actions;
 
-import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public interface SkillActionEffect {
-    void execute(PlayerEntity player, World world, BlockPos pos);
+    // Changed from PlayerEntity to Entity to support targeting mobs
+    void execute(Entity target, World world, BlockPos pos);
 }

--- a/src/main/java/com/jd_skill_tree/skills/actions/SkillActionHandler.java
+++ b/src/main/java/com/jd_skill_tree/skills/actions/SkillActionHandler.java
@@ -2,68 +2,60 @@ package com.jd_skill_tree.skills.actions;
 
 import com.jd_skill_tree.api.IUnlockedSkillsData;
 import com.jd_skill_tree.skills.SkillManager;
+import net.fabricmc.fabric.api.event.player.AttackEntityCallback;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class SkillActionHandler {
 
-    /**
-     * Registers the initial event listeners.
-     * Called in ModRegistries.
-     */
     public static void register() {
-        // Listen for Block Break events
+        // Block Break
         PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, blockEntity) -> {
             if (!world.isClient) {
-                triggerActions(player, world, pos, TriggerType.BLOCK_BREAK);
+                // Target is Player, but Pos is Block location
+                triggerActions(player, TriggerType.BLOCK_BREAK, player, world, pos);
             }
+        });
+
+        // Attack Entity
+        AttackEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> {
+            if (!world.isClient && !player.isSpectator()) {
+
+                // 1. ATTACK_TARGET:
+                // Owner = Player, Target = Zombie.
+                // Commands use Zombie as source (@s = Zombie, ~ ~ ~ = Zombie Pos)
+                triggerActions(player, TriggerType.ATTACK_TARGET, entity, world, entity.getBlockPos());
+
+                // 2. ATTACK_SELF:
+                // Owner = Player, Target = Player.
+                // Commands use Player as source (@s = Player, ~ ~ ~ = Player Pos)
+                triggerActions(player, TriggerType.ATTACK_SELF, player, world, player.getBlockPos());
+            }
+            return ActionResult.PASS;
         });
     }
 
-    /**
-     * Handles event-based triggers (Block Break, Block Place).
-     * This is also called from your Mixins (like BlockItemMixin).
-     */
-    public static void triggerActions(PlayerEntity player, World world, BlockPos pos, TriggerType type) {
-        IUnlockedSkillsData skillData = (IUnlockedSkillsData) player;
+    public static void triggerActions(PlayerEntity owner, TriggerType type, Entity target, World world, BlockPos pos) {
+        IUnlockedSkillsData skillData = (IUnlockedSkillsData) owner;
 
         for (String skillId : skillData.getUnlockedSkills()) {
             SkillManager.getSkill(new Identifier(skillId)).ifPresent(skill -> {
-
                 for (SkillAction action : skill.getActions()) {
                     if (action.getTrigger() == type) {
-                        // The action.run() method now checks action.shouldRun() internally
-                        action.run(player, world, pos);
+                        action.run(owner, target, world, pos);
                     }
                 }
             });
         }
     }
 
-    /**
-     * Handles timer-based triggers.
-     * Called from PlayerEntityMixin's tick method.
-     */
     public static void handleTimerActions(PlayerEntity player) {
         if (player.getWorld().isClient) return;
-
-        IUnlockedSkillsData skillData = (IUnlockedSkillsData) player;
-
-        for (String skillId : skillData.getUnlockedSkills()) {
-            SkillManager.getSkill(new Identifier(skillId)).ifPresent(skill -> {
-
-                for (SkillAction action : skill.getActions()) {
-                    // Check if it's a timer and if it's the right tick to fire
-                    if (action.getTrigger() == TriggerType.TIMER) {
-                        if (player.age % Math.max(1, action.getInterval()) == 0) {
-                            action.run(player, player.getWorld(), player.getBlockPos());
-                        }
-                    }
-                }
-            });
-        }
+        triggerActions(player, TriggerType.TIMER, player, player.getWorld(), player.getBlockPos());
     }
 }

--- a/src/main/java/com/jd_skill_tree/skills/actions/TriggerType.java
+++ b/src/main/java/com/jd_skill_tree/skills/actions/TriggerType.java
@@ -3,5 +3,10 @@ package com.jd_skill_tree.skills.actions;
 public enum TriggerType {
     BLOCK_BREAK,
     BLOCK_PLACE,
-    TIMER
+    TIMER,
+    TAKE_DAMAGE_SELF,
+    TAKE_DAMAGE_ATTACKER,
+    UNLOCK,
+    ATTACK_TARGET,
+    ATTACK_SELF
 }


### PR DESCRIPTION
Implemented 5 new action triggers to expand combat and progression logic:

- ATTACK_TARGET: Executes actions on the entity being hit (e.g., specific command targeting @s).
- ATTACK_SELF: Executes actions on the player when they hit something.
- TAKE_DAMAGE_SELF: Triggered when the player takes damage (Self context).
- TAKE_DAMAGE_ATTACKER: Triggered on the source of damage (Thorns-like context).
- UNLOCK: Fires a one-time action immediately upon unlocking a skill.

Refactored CommandActionEffect to support dynamic command sources based on target entities.