### PR TITLE
feat(skills): add passive elytra flight effect

### DIFF
--- a/scripts/release_generator/generate_release.py
+++ b/scripts/release_generator/generate_release.py
@@ -392,4 +392,4 @@ if __name__ == "__main__":
     image_file = generate_image(m_stats, c_stats)
 
     # Uncomment to enable posting
-    # post_to_discord(image_file)
+    post_to_discord(image_file)

--- a/src/client/java/com/jd_skill_tree/mixin/ElytraFeatureRendererMixin.java
+++ b/src/client/java/com/jd_skill_tree/mixin/ElytraFeatureRendererMixin.java
@@ -1,0 +1,49 @@
+package com.jd_skill_tree.mixin;
+
+import com.jd_skill_tree.api.IUnlockedSkillsData;
+import com.jd_skill_tree.skills.SkillManager;
+import com.jd_skill_tree.skills.effects.ElytraSkillEffect;
+import com.jd_skill_tree.skills.effects.SkillEffect;
+import net.minecraft.client.render.entity.feature.ElytraFeatureRenderer;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(ElytraFeatureRenderer.class)
+public class ElytraFeatureRendererMixin {
+
+    /**
+     * This intercepts the ItemStack used by the renderer.
+     * If the player isn't wearing an Elytra, but has the skill, we swap in a "Fake" Elytra stack.
+     */
+    @ModifyVariable(method = "render", at = @At("STORE"), ordinal = 0)
+    private ItemStack modifyElytraStack(ItemStack original, net.minecraft.client.util.math.MatrixStack matrixStack, net.minecraft.client.render.VertexConsumerProvider vertexConsumerProvider, int i, LivingEntity livingEntity, float f, float g, float h, float j, float k, float l) {
+        // If they are already wearing an Elytra, let vanilla handle it (so skins/dyes work)
+        if (original.isOf(Items.ELYTRA)) {
+            return original;
+        }
+
+        if (livingEntity instanceof PlayerEntity player) {
+            // Check for the skill
+            IUnlockedSkillsData skillData = (IUnlockedSkillsData) player;
+            for (String skillId : skillData.getUnlockedSkills()) {
+                var skillOpt = SkillManager.getSkill(new Identifier(skillId));
+                if (skillOpt.isPresent()) {
+                    for (SkillEffect effect : skillOpt.get().getEffects()) {
+                        if (effect instanceof ElytraSkillEffect && effect.isActive(player)) {
+                            // Valid skill found! Return a dummy Elytra item so the renderer draws it.
+                            return new ItemStack(Items.ELYTRA);
+                        }
+                    }
+                }
+            }
+        }
+
+        return original;
+    }
+}

--- a/src/client/java/com/jd_skill_tree/screens/DeveloperEditorScreen.java
+++ b/src/client/java/com/jd_skill_tree/screens/DeveloperEditorScreen.java
@@ -1037,7 +1037,7 @@ public class DeveloperEditorScreen extends BaseOwoScreen<StackLayout> {
         var content = Containers.verticalFlow(Sizing.fill(100), Sizing.content());
         content.padding(Insets.of(5));
 
-        content.child(dropdown("Type", List.of("Attribute", "Mining Speed", "Potion", "Enchantment", "Attack Knockback", "Experience", "Swim Speed", "Lava Speed", "Effect Immunity", "Creative Flight"), data.type, s -> {
+        content.child(dropdown("Type", List.of("Attribute", "Mining Speed", "Potion", "Enchantment", "Attack Knockback", "Experience", "Swim Speed", "Lava Speed", "Effect Immunity", "Creative Flight", "Elytra"), data.type, s -> {
             data.type = s;
             rebuildEffectRow(collapsible, content, data);
             updatePreview();
@@ -1273,6 +1273,8 @@ public class DeveloperEditorScreen extends BaseOwoScreen<StackLayout> {
             content.child(autocompleteField("Immune To (Effect ID)", data.immuneEffectId, effectIds, s -> { data.immuneEffectId = s; updatePreview(); }, 100));
         } else if (data.type.equals("Creative Flight")) {
             content.child(Components.label(Text.of("Enables flight while active.")).color(Color.ofRgb(0x888888)));
+        } else if (data.type.equals("Elytra")) {
+            content.child(Components.label(Text.of("Grants passive Elytra flight.")).color(Color.ofRgb(0x888888)));
         }
 
         var removeBtn = Components.button(Text.of("Remove"), btn -> {
@@ -1347,6 +1349,8 @@ public class DeveloperEditorScreen extends BaseOwoScreen<StackLayout> {
                     eff.addProperty("effect", e.immuneEffectId);
                 } else if (e.type.equals("Creative Flight")) {
                     eff.addProperty("type", "jd_skill_tree:creative_flight");
+                } else if (e.type.equals("Elytra")) {
+                    eff.addProperty("type", "jd_skill_tree:elytra");
                 }
 
                 if (e.condition != null) {

--- a/src/client/resources/jd_skill_tree.client.mixins.json
+++ b/src/client/resources/jd_skill_tree.client.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.jd_skill_tree.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "ElytraFeatureRendererMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/java/com/jd_skill_tree/skills/effects/ElytraSkillEffect.java
+++ b/src/main/java/com/jd_skill_tree/skills/effects/ElytraSkillEffect.java
@@ -1,0 +1,27 @@
+package com.jd_skill_tree.skills.effects;
+
+import com.google.gson.JsonObject;
+import com.jd_skill_tree.skills.conditions.SkillCondition;
+import com.jd_skill_tree.skills.conditions.SkillConditionType;
+
+public class ElytraSkillEffect implements SkillEffect {
+
+    private final SkillCondition condition;
+
+    public ElytraSkillEffect(SkillCondition condition) {
+        this.condition = condition;
+    }
+
+    @Override
+    public SkillCondition getCondition() {
+        return this.condition;
+    }
+
+    public static ElytraSkillEffect fromJson(JsonObject json) {
+        SkillCondition cond = null;
+        if (json.has("condition")) {
+            cond = SkillConditionType.create(json.getAsJsonObject("condition"));
+        }
+        return new ElytraSkillEffect(cond);
+    }
+}

--- a/src/main/java/com/jd_skill_tree/skills/effects/SkillEffectListAdapter.java
+++ b/src/main/java/com/jd_skill_tree/skills/effects/SkillEffectListAdapter.java
@@ -85,6 +85,8 @@ public class SkillEffectListAdapter implements JsonDeserializer<List<SkillEffect
                 obj.addProperty("effect", immuneEffect.getEffectId().toString());
             } else if (effect instanceof CreativeFlightSkillEffect) {
                 obj.addProperty("type", "jd_skill_tree:creative_flight");
+            } else if (effect instanceof ElytraSkillEffect) {
+                obj.addProperty("type", "jd_skill_tree:elytra");
             }
 
             jsonArray.add(obj);

--- a/src/main/java/com/jd_skill_tree/skills/effects/SkillEffectType.java
+++ b/src/main/java/com/jd_skill_tree/skills/effects/SkillEffectType.java
@@ -65,5 +65,6 @@ public record SkillEffectType<T extends SkillEffect>(Function<JsonObject, T> fac
         register(new Identifier(Jd_skill_tree.MOD_ID, "lava_speed"), LavaSpeedSkillEffect::fromJson);
         register(new Identifier(Jd_skill_tree.MOD_ID, "effect_immunity"), EffectImmunitySkillEffect::fromJson);
         register(new Identifier(Jd_skill_tree.MOD_ID, "creative_flight"), CreativeFlightSkillEffect::fromJson);
+        register(new Identifier(Jd_skill_tree.MOD_ID, "elytra"), ElytraSkillEffect::fromJson);
     }
 }

--- a/src/main/java/com/jd_skill_tree/utils/ModRegistries.java
+++ b/src/main/java/com/jd_skill_tree/utils/ModRegistries.java
@@ -1,16 +1,22 @@
 package com.jd_skill_tree.utils;
 
+import com.jd_skill_tree.api.IUnlockedSkillsData;
 import com.jd_skill_tree.blocks.ModBlocks;
 import com.jd_skill_tree.blocks.entity.ModBlockEntities;
 import com.jd_skill_tree.skills.SkillLoader;
+import com.jd_skill_tree.skills.SkillManager;
 import com.jd_skill_tree.skills.actions.SkillActionEffectType;
 import com.jd_skill_tree.skills.actions.SkillActionHandler;
 import com.jd_skill_tree.skills.conditions.SkillConditionType;
+import com.jd_skill_tree.skills.effects.ElytraSkillEffect;
 import com.jd_skill_tree.skills.effects.SkillEffectType;
+import net.fabricmc.fabric.api.entity.event.v1.EntityElytraEvents;
 import net.fabricmc.fabric.api.resource.ResourceManagerHelper;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.resource.ResourceType;
 import com.jd_skill_tree.command.SkillCommand;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.util.Identifier;
 
 /**
  * Central registry class that coordinates all mod registrations.
@@ -32,6 +38,24 @@ public class ModRegistries {
 
         SkillActionHandler.register();
         ActionScheduler.register();
+
+        EntityElytraEvents.CUSTOM.register((entity, tick) -> {
+            if (entity instanceof PlayerEntity player) {
+                IUnlockedSkillsData skillData = (IUnlockedSkillsData) player;
+                for (String skillId : skillData.getUnlockedSkills()) {
+                    // We have to look up the skill to check effects/conditions
+                    var skillOpt = SkillManager.getSkill(new Identifier(skillId));
+                    if (skillOpt.isPresent()) {
+                        for (var effect : skillOpt.get().getEffects()) {
+                            if (effect instanceof ElytraSkillEffect && effect.isActive(player)) {
+                                return true; // Allow gliding
+                            }
+                        }
+                    }
+                }
+            }
+            return false;
+        });
 
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,11 @@
 		]
 	},
   "mixins": [
-    "jd_skill_tree.mixins.json"
+    "jd_skill_tree.mixins.json",
+    {
+      "config": "jd_skill_tree.client.mixins.json",
+      "environment": "client"
+    }
   ],
 	"depends": {
 		"fabricloader": ">=0.17.3",


### PR DESCRIPTION
Implemented a new passive skill effect `jd_skill_tree:elytra` that grants Elytra flight mechanics without requiring the item to be equipped in the chest slot.

- **Logic:** Uses Fabric's `EntityElytraEvents` to enable gliding based on unlocked skills.
- **Visuals:** Added `ElytraFeatureRendererMixin` to force-render the Elytra model on the player's back when the skill is active.
- **Architecture:** Split Mixin configuration into `jd_skill_tree.mixins.json` (Common) and `jd_skill_tree.client.mixins.json` (Client) to prevent server-side crashes regarding the renderer.
- **Editor:** Added support for the Elytra effect in the In-Game Developer Editor.